### PR TITLE
Add a simple, data-driven Switchy module for self-customisation.

### DIFF
--- a/src/main/java/xyz/amymialee/elegantarmour/cca/ArmourComponent.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/cca/ArmourComponent.java
@@ -15,8 +15,10 @@ import xyz.amymialee.elegantarmour.util.ElegantState;
 
 public class ArmourComponent implements AutoSyncedComponent {
 	public final ElegantPlayerData data;
+	private final PlayerEntity player;
 
 	public ArmourComponent(PlayerEntity player) {
+		this.player = player;
 		if (player.getWorld().isClient()) {
 			if (ElegantArmourConfig.playerData.containsKey(player.getUuid())) {
 				this.data = ElegantArmourConfig.playerData.get(player.getUuid());
@@ -31,22 +33,21 @@ public class ArmourComponent implements AutoSyncedComponent {
 
 	@Override
 	public void readFromNbt(NbtCompound tag) {
-		this.data.setHeadState(ElegantState.values()[tag.getInt("headState")]);
-		this.data.setChestState(ElegantState.values()[tag.getInt("chestState")]);
-		this.data.setLegsState(ElegantState.values()[tag.getInt("legsState")]);
-		this.data.setFeetState(ElegantState.values()[tag.getInt("feetState")]);
-		this.data.setElytraState(ElegantState.values()[tag.getInt("elytraState")]);
-		this.data.setSmallArmourState(ElegantState.values()[tag.getInt("smallArmour")]);
+		this.data.readFromNbt(tag);
+		ElegantArmour.ARMOUR.sync(this.player);
 	}
 
 	@Override
 	public void writeToNbt(NbtCompound tag) {
-		tag.putInt("headState", this.data.getHeadState().ordinal());
-		tag.putInt("chestState", this.data.getChestState().ordinal());
-		tag.putInt("legsState", this.data.getLegsState().ordinal());
-		tag.putInt("feetState", this.data.getFeetState().ordinal());
-		tag.putInt("elytraState", this.data.getElytraState().ordinal());
-		tag.putInt("smallArmour", this.data.getSmallArmourState().ordinal());
+		this.data.writeToNbt(tag);
+	}
+
+	@Override
+	public void applySyncPacket(PacketByteBuf buf) {
+		NbtCompound tag = buf.readNbt();
+		if (tag != null) {
+			this.data.readFromNbt(tag);
+		}
 	}
 
 	public static void handleClientUpdate(ServerPlayerEntity serverPlayerEntity, PacketByteBuf buf) {

--- a/src/main/java/xyz/amymialee/elegantarmour/util/ElegantPlayerData.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/util/ElegantPlayerData.java
@@ -1,6 +1,7 @@
 package xyz.amymialee.elegantarmour.util;
 
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.nbt.NbtCompound;
 
 public class ElegantPlayerData {
     private final String playerName;
@@ -10,6 +11,12 @@ public class ElegantPlayerData {
     private ElegantState feetState = ElegantState.DEFAULT;
     private ElegantState elytraState = ElegantState.DEFAULT;
     private ElegantState smallArmourState = ElegantState.DEFAULT;
+    private static final String KEY_HEAD_STATE = "headState"; 
+    private static final String KEY_CHEST_STATE = "chestState"; 
+    private static final String KEY_LEGS_STATE = "legsState"; 
+    private static final String KEY_FEET_STATE = "feetState"; 
+    private static final String KEY_ELYTRA_STATE = "elytraState"; 
+    private static final String KEY_SMALL_ARMOUR_STATE = "smallArmour";
 
     public ElegantPlayerData(String playerName) {
         this.playerName = playerName;
@@ -50,6 +57,24 @@ public class ElegantPlayerData {
             case FEET -> this.feetState;
             default -> ElegantState.DEFAULT;
         };
+    }
+    
+    public void readFromNbt(NbtCompound tag) {
+        setHeadState(ElegantState.values()[tag.getInt(KEY_HEAD_STATE)]);
+        setChestState(ElegantState.values()[tag.getInt(KEY_CHEST_STATE)]);
+        setLegsState(ElegantState.values()[tag.getInt(KEY_LEGS_STATE)]);
+        setFeetState(ElegantState.values()[tag.getInt(KEY_FEET_STATE)]);
+        setElytraState(ElegantState.values()[tag.getInt(KEY_ELYTRA_STATE)]);
+        setSmallArmourState(ElegantState.values()[tag.getInt(KEY_SMALL_ARMOUR_STATE)]);
+    }
+
+    public void writeToNbt(NbtCompound tag) {
+        tag.putInt(KEY_HEAD_STATE, getHeadState().ordinal());
+        tag.putInt(KEY_CHEST_STATE, getChestState().ordinal());
+        tag.putInt(KEY_LEGS_STATE, getLegsState().ordinal());
+        tag.putInt(KEY_FEET_STATE, getFeetState().ordinal());
+        tag.putInt(KEY_ELYTRA_STATE, getElytraState().ordinal());
+        tag.putInt(KEY_SMALL_ARMOUR_STATE, getSmallArmourState().ordinal());
     }
 
     public ElegantState getHeadState() {

--- a/src/main/resources/assets/elegantarmour/lang/en_us.json
+++ b/src/main/resources/assets/elegantarmour/lang/en_us.json
@@ -13,5 +13,7 @@
   "options.elegantarmour.leggings": "Leggings",
   "options.elegantarmour.boots": "Boots",
   "options.elegantarmour.elytra": "Elytra",
-  "options.elegantarmour.small": "Slim Armour"
+  "options.elegantarmour.small": "Slim Armour",
+
+  "switchy.modules.elegantarmour.armour.preview.tooltip": "Helmet: %s Chestplate: %s Leggings: %s Boots: %s Elytra: %s Slim: %s"
 }

--- a/src/main/resources/assets/elegantarmour/switchy_cardinal/armour.json
+++ b/src/main/resources/assets/elegantarmour/switchy_cardinal/armour.json
@@ -1,0 +1,13 @@
+{
+  "icon": {
+    "id": "minecraft:leather_chestplate"
+  },
+  "values": [
+    "elegantarmour:armour.headState",
+    "elegantarmour:armour.chestState",
+    "elegantarmour:armour.legsState",
+    "elegantarmour:armour.feetState",
+    "elegantarmour:armour.elytraState",
+    "elegantarmour:armour.smallArmour"
+  ]
+}

--- a/src/main/resources/data/elegantarmour/lang/en_us.json
+++ b/src/main/resources/data/elegantarmour/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+	"switchy.modules.elegantarmour.armour.description": "A module that switches armour customisation from AmyMialee's Elegant Armour.",
+	"switchy.modules.elegantarmour.armour.enabled": "You will have armour customisation settings per-preset.",
+	"switchy.modules.elegantarmour.armour.disabled": "You will have the same armour customisation settings for all presets.",
+	"switchy.modules.elegantarmour.armour.warning": "All other armour customisation settings will be cleared!"
+}

--- a/src/main/resources/data/elegantarmour/switchy_cardinal/armour.json
+++ b/src/main/resources/data/elegantarmour/switchy_cardinal/armour.json
@@ -1,0 +1,7 @@
+{
+  "default": false,
+  "editable": "ALLOWED",
+  "components": [
+    "elegantarmour:armour"
+  ]
+}


### PR DESCRIPTION
iiit's busted - I think maybe `.sync` sync's to everyone *but* the provider? but we need everyone including the provider. here's how it looks though.

By default, with Switchy installed, nothing happens. If a Switchy user opens their UI and naviagtes to Modules, they'll see this:

![image](https://github.com/AmyMialeeMods/elegantarmour/assets/55819817/346b5e42-7122-48e4-b2a5-b419834e0171)

They can then click the enable button, which has a tooltip indicating the effect.

![image](https://github.com/AmyMialeeMods/elegantarmour/assets/55819817/5a7e1847-ded4-44d7-b27a-106640f06dea)

Once it's enabled, customisation state is stored per preset, which is visible via this (difficult to read - the data-driven preview format isn't great for enums yet) tooltip

![image](https://github.com/AmyMialeeMods/elegantarmour/assets/55819817/ebad3b74-4aac-46af-adf5-9d1b00ba6dbb)

Right now the problem is that swapping in a new preset does not uh, actually manage to pass that to the client. saving stuff works great! applying it doesn't.