### PR TITLE
Allow default options screen title to be localized. Fixes #8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    maven { url "https://ladysnake.jfrog.io/artifactory/mods" }
+    maven { url "https://maven.ladysnake.org/releases" }
     maven { url "https://jitpack.io" }
     maven { url "https://repo.unascribed.com" }
 }

--- a/src/main/java/xyz/amymialee/elegantarmour/client/ElegantOptionsScreen.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/client/ElegantOptionsScreen.java
@@ -98,7 +98,7 @@ public class ElegantOptionsScreen extends Screen {
             }
             drawEntity(context, this.x + 39, this.y + 118, 46, (float) (this.x + 39) - mouseX, (float) (this.y + 46) - mouseY, backupEntity);
         }
-        Text name = Text.literal(this.data.getPlayerName()).append(" ").append(Text.translatable("options.elegantCustomisation"));
+        Text name = this.data == ElegantArmourConfig.defaultSettings ? Text.translatable("options.elegantDefault") : Text.literal(this.data.getPlayerName()).append(" ").append(Text.translatable("options.elegantCustomisation"));
         context.drawText(this.textRenderer, name, this.width / 2 - this.textRenderer.getWidth(name) / 2, this.y + 7, 4210752, false);
         super.render(context, mouseX, mouseY, delta);
     }


### PR DESCRIPTION
It looks like #8 is a result of the default options requiring a player name. While there are a few ways to work around this I went with a reference check to avoid changing the data structure of your config objects.