### PR TITLE
Fix initial sync not doing anything, fix player name in ElegentState always being empty, make social interactions armour button only shiny for ppl with the mod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,10 @@ processResources {
     }
 }
 
+loom {
+    accessWidenerPath = file("src/main/resources/${project.mod_id}.accesswidener")
+}
+
 tasks.withType(JavaCompile).configureEach {
     options.encoding = "UTF-8"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,6 +9,7 @@ loader_version=0.16.5
 # Mod Properties
 mod_version = 1.2.0
 maven_group = xyz.amymialee
+mod_id = elegantarmour
 archives_base_name = elegantarmour
 
 # Publishing

--- a/src/main/java/xyz/amymialee/elegantarmour/ElegantArmour.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/ElegantArmour.java
@@ -6,22 +6,64 @@ import dev.onyxstudios.cca.api.v3.entity.EntityComponentFactoryRegistry;
 import dev.onyxstudios.cca.api.v3.entity.EntityComponentInitializer;
 import dev.onyxstudios.cca.api.v3.entity.RespawnCopyStrategy;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+import net.fabricmc.fabric.api.entity.event.v1.ServerPlayerEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerLoginConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerLoginNetworking;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.Uuids;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import xyz.amymialee.elegantarmour.cca.ArmourComponent;
+import xyz.amymialee.elegantarmour.util.ElegantPlayerData;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class ElegantArmour implements ModInitializer, EntityComponentInitializer {
     public static final String MOD_ID = "elegantarmour";
     public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
     public static final Identifier CLIENT_UPDATE = id("client_update");
+    public static final Identifier CLIENT_INIT_QUERY = id("client_init_query");
     public static final ComponentKey<ArmourComponent> ARMOUR = ComponentRegistry.getOrCreate(ElegantArmour.id("armour"), ArmourComponent.class);
+    public static final Map<UUID, Optional<PacketByteBuf>> PENDING_INITIALISATIONS = new ConcurrentHashMap<>();
 
     @Override
     public void onInitialize() {
         ServerPlayNetworking.registerGlobalReceiver(CLIENT_UPDATE, (server, player, networkHandler, buf, sender) -> ArmourComponent.handleClientUpdate(player, buf));
+        ServerLoginConnectionEvents.QUERY_START.register((handler, server, sender, synchronizer) -> {
+            sender.sendPacket(CLIENT_INIT_QUERY, PacketByteBufs.create());
+        });
+        ServerLoginNetworking.registerGlobalReceiver(CLIENT_INIT_QUERY, (server, handler, understood, buf, synchronizer, responseSender) -> {
+            if (handler.profile != null) {
+                // waitFor just to guard against race conditions - we want to make sure we're done here before the player logs in and the
+                // pending initialisation is retrieved
+                synchronizer.waitFor(server.submit(() -> {
+                    // player does not exist yet, so we defer the actual initialisation
+                    UUID uuid = Uuids.getUuidFromProfile(handler.profile);
+                    if (understood) {
+                        PENDING_INITIALISATIONS.put(uuid, Optional.of(PacketByteBufs.copy(buf)));
+                    } else {
+                        PENDING_INITIALISATIONS.put(uuid, Optional.empty());
+                    }
+                }));
+            }
+        });
+        // sync data pack contents happens after the player is fully initialised
+        // why can't we do init in the constructor of ArmourComponent? because components
+        // are constructed before the player has their profile / uuid set, so we don't
+        // know who they are
+        ServerLifecycleEvents.SYNC_DATA_PACK_CONTENTS.register((player, joined) -> {
+            ArmourComponent.handleInit(player);
+        });
     }
 
     @Override

--- a/src/main/java/xyz/amymialee/elegantarmour/ElegantArmourClient.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/ElegantArmourClient.java
@@ -71,12 +71,7 @@ public class ElegantArmourClient implements ClientModInitializer {
         PlayerEntity player = MinecraftClient.getInstance().player;
         if (player == null) return;
         PacketByteBuf buf = PacketByteBufs.create();
-        buf.writeInt(ElegantArmourConfig.playerData.get(player.getUuid()).getHeadState().ordinal());
-        buf.writeInt(ElegantArmourConfig.playerData.get(player.getUuid()).getChestState().ordinal());
-        buf.writeInt(ElegantArmourConfig.playerData.get(player.getUuid()).getLegsState().ordinal());
-        buf.writeInt(ElegantArmourConfig.playerData.get(player.getUuid()).getFeetState().ordinal());
-        buf.writeInt(ElegantArmourConfig.playerData.get(player.getUuid()).getElytraState().ordinal());
-        buf.writeInt(ElegantArmourConfig.playerData.get(player.getUuid()).getSmallArmourState().ordinal());
+        ElegantArmourConfig.playerData.get(player.getUuid()).writeToBuf(buf);
         ClientPlayNetworking.send(ElegantArmour.CLIENT_UPDATE, buf);
     }
 

--- a/src/main/java/xyz/amymialee/elegantarmour/ElegantArmourClient.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/ElegantArmourClient.java
@@ -1,7 +1,11 @@
 package xyz.amymialee.elegantarmour;
 
 import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientEntityEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientLoginConnectionEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientLoginNetworking;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
 import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
@@ -19,9 +23,12 @@ import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.text.Text;
+import xyz.amymialee.elegantarmour.cca.ArmourComponent;
 import xyz.amymialee.elegantarmour.compat.EarsCompat;
 import xyz.amymialee.elegantarmour.util.ElegantPlayerData;
 import xyz.amymialee.elegantarmour.util.ElegantState;
+
+import java.util.concurrent.CompletableFuture;
 
 public class ElegantArmourClient implements ClientModInitializer {
     public static final EntityModelLayer SLIM_BODY_LAYER = new EntityModelLayer(ElegantArmour.id("slim_body_layer"), "main");
@@ -41,7 +48,24 @@ public class ElegantArmourClient implements ClientModInitializer {
             } catch (Throwable ignored) {}
         }
         ElegantArmourConfig.loadConfig();
-        ClientLoginConnectionEvents.INIT.register((networkHandler, client) -> syncC2S());
+        ClientLoginNetworking.registerGlobalReceiver(ElegantArmour.CLIENT_INIT_QUERY, (client, handler, queryBuf, listenerAdder) -> {
+            PacketByteBuf responseBuf = PacketByteBufs.create();
+            var uuid = client.getSession().getUuidOrNull(); // client.player is null at this point, we get uuid from elsewhere
+            String name = client.getSession().getUsername();
+            if (uuid != null) {
+                ElegantArmourConfig.getOrCreate(uuid, name).writeToBuf(responseBuf);
+                return CompletableFuture.completedFuture(responseBuf);
+            }
+
+            // we have no uuid, so we have no data to send
+            return CompletableFuture.completedFuture(null);
+        });
+
+        ClientEntityEvents.ENTITY_LOAD.register((entity, world) -> {
+            if (entity instanceof PlayerEntity player) {
+                ArmourComponent.handleInit(player);
+            }
+        });
     }
 
     public static ElegantState getMainState(ElegantPlayerData local, ElegantPlayerData server, EquipmentSlot slot) {

--- a/src/main/java/xyz/amymialee/elegantarmour/cca/ArmourComponent.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/cca/ArmourComponent.java
@@ -14,6 +14,7 @@ import xyz.amymialee.elegantarmour.util.ElegantPlayerData;
 import xyz.amymialee.elegantarmour.util.ElegantState;
 
 public class ArmourComponent implements AutoSyncedComponent {
+	public boolean hasMod;
 	public final ElegantPlayerData data;
 
 	public ArmourComponent(PlayerEntity player) {
@@ -37,6 +38,7 @@ public class ArmourComponent implements AutoSyncedComponent {
 		this.data.setFeetState(ElegantState.values()[tag.getInt("feetState")]);
 		this.data.setElytraState(ElegantState.values()[tag.getInt("elytraState")]);
 		this.data.setSmallArmourState(ElegantState.values()[tag.getInt("smallArmour")]);
+		// hasMod is not persisted, as it may be different every time the player connects
 	}
 
 	@Override
@@ -49,14 +51,27 @@ public class ArmourComponent implements AutoSyncedComponent {
 		tag.putInt("smallArmour", this.data.getSmallArmourState().ordinal());
 	}
 
+	@Override
+	public void applySyncPacket(PacketByteBuf buf) {
+		this.data.setFromBuf(buf);
+
+		// if server is older version, this may be the end of the packet, so we check for that here
+		// FIXME this can be changed after a breaking update, e.g. an MC update
+		if (buf.readableBytes() > 0) {
+			this.hasMod = buf.readBoolean();
+		}
+	}
+
+	@Override
+	public void writeSyncPacket(PacketByteBuf buf, ServerPlayerEntity player) {
+		this.data.writeToBuf(buf);
+		buf.writeBoolean(this.hasMod);
+	}
+
 	public static void handleClientUpdate(ServerPlayerEntity serverPlayerEntity, PacketByteBuf buf) {
         var component = ElegantArmour.ARMOUR.get(serverPlayerEntity);
-		component.data.setHeadState(ElegantState.values()[buf.readInt()]);
-		component.data.setChestState(ElegantState.values()[buf.readInt()]);
-		component.data.setLegsState(ElegantState.values()[buf.readInt()]);
-		component.data.setFeetState(ElegantState.values()[buf.readInt()]);
-		component.data.setElytraState(ElegantState.values()[buf.readInt()]);
-		component.data.setSmallArmourState(ElegantState.values()[buf.readInt()]);
+		component.data.setFromBuf(buf);
+		component.hasMod = true; // if we've received a client update packet, we know the player has the mod
 		ElegantArmour.ARMOUR.sync(serverPlayerEntity);
 	}
 }

--- a/src/main/java/xyz/amymialee/elegantarmour/client/ElegantMenuWidget.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/client/ElegantMenuWidget.java
@@ -14,11 +14,11 @@ import java.util.UUID;
 public class ElegantMenuWidget extends ButtonWidget {
     private static final Identifier ELEGANT_TEXTURE = ElegantArmour.id("textures/gui/widgets.png");
     private static float cycle = 0f;
-    private final UUID uuid;
+    private final boolean shiny;
 
-    public ElegantMenuWidget(int x, int y, Text message, PressAction action, UUID uuid) {
+    public ElegantMenuWidget(int x, int y, Text message, PressAction action, boolean shiny) {
         super(x, y, 20, 20, message, action, DEFAULT_NARRATION_SUPPLIER);
-        this.uuid = uuid;
+        this.shiny = shiny;
     }
 
     @Override
@@ -29,7 +29,7 @@ public class ElegantMenuWidget extends ButtonWidget {
         RenderSystem.setShader(GameRenderer::getPositionTexProgram);
         RenderSystem.setShaderTexture(0, ELEGANT_TEXTURE);
         context.drawTexture(ELEGANT_TEXTURE, this.getX(), this.getY(), 0, !this.isHovered() ? 0 : 20, 20, 20, 64, 64);
-        if (this.uuid != null) {
+        if (this.shiny) {
             cycle = cycle + delta % 160;
             Color colour = Color.getHSBColor(cycle / 160f, 0.65f, 1.0f);
             RenderSystem.setShaderColor(colour.getRed() / 255f, colour.getGreen() / 255f, colour.getBlue() / 255f, 1.0F);

--- a/src/main/java/xyz/amymialee/elegantarmour/mixin/OptionsScreenMixin.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/mixin/OptionsScreenMixin.java
@@ -44,6 +44,6 @@ public class OptionsScreenMixin extends Screen {
         ButtonWidget buttonWidget = skin.get();
         buttonWidget.setX(buttonWidget.getX() - 10);
         ElegantPlayerData data = ElegantArmourConfig.getOrCreate(this.client.player.getUuid(), this.client.player.getEntityName());
-        this.addDrawableChild(new ElegantMenuWidget(this.width / 2 - 155 + 130, this.height / 6 + 48 - 6, Text.translatable("options.elegantCustomisation"), button -> this.client.setScreen(new ElegantOptionsScreen(this, this.client.player, data)), this.client.player.getUuid()));
+        this.addDrawableChild(new ElegantMenuWidget(this.width / 2 - 155 + 130, this.height / 6 + 48 - 6, Text.translatable("options.elegantCustomisation"), button -> this.client.setScreen(new ElegantOptionsScreen(this, this.client.player, data)), true));
     }
 }

--- a/src/main/java/xyz/amymialee/elegantarmour/mixin/SocialInteractionsPlayerListEntryMixin.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/mixin/SocialInteractionsPlayerListEntryMixin.java
@@ -18,6 +18,7 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.amymialee.elegantarmour.ElegantArmour;
 import xyz.amymialee.elegantarmour.ElegantArmourConfig;
 import xyz.amymialee.elegantarmour.client.ElegantMenuWidget;
 import xyz.amymialee.elegantarmour.client.ElegantOptionsScreen;
@@ -44,13 +45,13 @@ public class SocialInteractionsPlayerListEntryMixin {
         } else {
             player = null;
         }
-        this.elegantButton = new ElegantMenuWidget(0, 0, Text.translatable("options.elegantCustomisation"), button -> client.setScreen(new ElegantOptionsScreen(parent, player, data)), uuid);
+        this.elegantButton = new ElegantMenuWidget(0, 0, Text.translatable("options.elegantCustomisation"), button -> client.setScreen(new ElegantOptionsScreen(parent, player, data)), player != null && ElegantArmour.ARMOUR.get(player).hasMod);
         this.elegantButton.setTooltip(Tooltip.of(Text.translatable("options.elegantCustomisation")));
         this.elegantButton.setTooltipDelay(10);
         this.elegantButton.active = true;
         this.buttons.add(this.elegantButton);
         if (player == client.player) {
-            this.defaultButton = new ElegantMenuWidget(0, 0, Text.translatable("options.elegantDefault"), button -> client.setScreen(new ElegantOptionsScreen(parent, null, ElegantArmourConfig.defaultSettings)), null);
+            this.defaultButton = new ElegantMenuWidget(0, 0, Text.translatable("options.elegantDefault"), button -> client.setScreen(new ElegantOptionsScreen(parent, null, ElegantArmourConfig.defaultSettings)), false);
             this.defaultButton.setTooltip(Tooltip.of(Text.translatable("options.elegantDefault")));
             this.defaultButton.setTooltipDelay(10);
             this.defaultButton.active = true;

--- a/src/main/java/xyz/amymialee/elegantarmour/util/ElegantPlayerData.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/util/ElegantPlayerData.java
@@ -1,6 +1,7 @@
 package xyz.amymialee.elegantarmour.util;
 
 import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.network.PacketByteBuf;
 
 public class ElegantPlayerData {
     private final String playerName;
@@ -50,6 +51,25 @@ public class ElegantPlayerData {
             case FEET -> this.feetState;
             default -> ElegantState.DEFAULT;
         };
+    }
+
+    public void setFromBuf(PacketByteBuf buf) {
+        this.setHeadState(ElegantState.values()[buf.readInt()]);
+        this.setChestState(ElegantState.values()[buf.readInt()]);
+        this.setLegsState(ElegantState.values()[buf.readInt()]);
+        this.setFeetState(ElegantState.values()[buf.readInt()]);
+        this.setElytraState(ElegantState.values()[buf.readInt()]);
+        this.setSmallArmourState(ElegantState.values()[buf.readInt()]);
+    }
+
+    public void writeToBuf(PacketByteBuf buf) {
+        // FIXME ideally this would be bytes or varints but we can't change it until a breaking update (e.g. minecraft update)
+        buf.writeInt(this.getHeadState().ordinal());
+        buf.writeInt(this.getChestState().ordinal());
+        buf.writeInt(this.getLegsState().ordinal());
+        buf.writeInt(this.getFeetState().ordinal());
+        buf.writeInt(this.getElytraState().ordinal());
+        buf.writeInt(this.getSmallArmourState().ordinal());
     }
 
     public ElegantState getHeadState() {

--- a/src/main/java/xyz/amymialee/elegantarmour/util/ElegantPlayerData.java
+++ b/src/main/java/xyz/amymialee/elegantarmour/util/ElegantPlayerData.java
@@ -2,9 +2,10 @@ package xyz.amymialee.elegantarmour.util;
 
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.network.PacketByteBuf;
+import xyz.amymialee.elegantarmour.ElegantArmour;
 
 public class ElegantPlayerData {
-    private final String playerName;
+    private String playerName;
     private ElegantState headState = ElegantState.DEFAULT;
     private ElegantState chestState = ElegantState.DEFAULT;
     private ElegantState legsState = ElegantState.DEFAULT;
@@ -13,6 +14,10 @@ public class ElegantPlayerData {
     private ElegantState smallArmourState = ElegantState.DEFAULT;
 
     public ElegantPlayerData(String playerName) {
+        this.playerName = playerName;
+    }
+
+    public void setPlayerName(String playerName) {
         this.playerName = playerName;
     }
 
@@ -54,22 +59,21 @@ public class ElegantPlayerData {
     }
 
     public void setFromBuf(PacketByteBuf buf) {
-        this.setHeadState(ElegantState.values()[buf.readInt()]);
-        this.setChestState(ElegantState.values()[buf.readInt()]);
-        this.setLegsState(ElegantState.values()[buf.readInt()]);
-        this.setFeetState(ElegantState.values()[buf.readInt()]);
-        this.setElytraState(ElegantState.values()[buf.readInt()]);
-        this.setSmallArmourState(ElegantState.values()[buf.readInt()]);
+        this.setHeadState(ElegantState.values()[buf.readByte()]);
+        this.setChestState(ElegantState.values()[buf.readByte()]);
+        this.setLegsState(ElegantState.values()[buf.readByte()]);
+        this.setFeetState(ElegantState.values()[buf.readByte()]);
+        this.setElytraState(ElegantState.values()[buf.readByte()]);
+        this.setSmallArmourState(ElegantState.values()[buf.readByte()]);
     }
 
     public void writeToBuf(PacketByteBuf buf) {
-        // FIXME ideally this would be bytes or varints but we can't change it until a breaking update (e.g. minecraft update)
-        buf.writeInt(this.getHeadState().ordinal());
-        buf.writeInt(this.getChestState().ordinal());
-        buf.writeInt(this.getLegsState().ordinal());
-        buf.writeInt(this.getFeetState().ordinal());
-        buf.writeInt(this.getElytraState().ordinal());
-        buf.writeInt(this.getSmallArmourState().ordinal());
+        buf.writeByte(this.getHeadState().ordinal());
+        buf.writeByte(this.getChestState().ordinal());
+        buf.writeByte(this.getLegsState().ordinal());
+        buf.writeByte(this.getFeetState().ordinal());
+        buf.writeByte(this.getElytraState().ordinal());
+        buf.writeByte(this.getSmallArmourState().ordinal());
     }
 
     public ElegantState getHeadState() {
@@ -118,5 +122,15 @@ public class ElegantPlayerData {
 
     public void setSmallArmourState(ElegantState smallArmourState) {
         this.smallArmourState = smallArmourState;
+    }
+
+    public void setFrom(ElegantPlayerData elegantPlayerData) {
+        this.playerName = elegantPlayerData.playerName;
+        this.headState = elegantPlayerData.headState;
+        this.chestState = elegantPlayerData.chestState;
+        this.legsState = elegantPlayerData.legsState;
+        this.feetState = elegantPlayerData.feetState;
+        this.elytraState = elegantPlayerData.elytraState;
+        this.smallArmourState = elegantPlayerData.smallArmourState;
     }
 }

--- a/src/main/resources/elegantarmour.accesswidener
+++ b/src/main/resources/elegantarmour.accesswidener
@@ -1,0 +1,2 @@
+accessWidener v2 named
+accessible field net/minecraft/server/network/ServerLoginNetworkHandler profile Lcom/mojang/authlib/GameProfile;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,6 +25,7 @@
       "xyz.amymialee.elegantarmour.ElegantArmour"
     ]
   },
+  "accessWidener": "elegantarmour.accesswidener",
   "mixins": [
     "elegantarmour.mixins.json"
   ],


### PR DESCRIPTION
A load of things were being done too early:
- initial sync was done before player is initialised or play phase had started, so the initial c2s sync packet didn't go anywhere
- armourcomponent is constructed before player has the correct UUID or any non-null game profile

also made the sync packets wayyyy smaller (130bytes -> 32bytes)

these changes are breaking !! an older version of the mod cannot communicate with a newer version.

closes #6 